### PR TITLE
Fix GitHub Actions permission to the organization

### DIFF
--- a/.github/workflows/most-helpful-contributors.yml
+++ b/.github/workflows/most-helpful-contributors.yml
@@ -5,21 +5,6 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  discussions: write
-  actions: write
-  checks: write
-  deployments: write
-  id-token: write
-  issues: write
-  packages: write
-  pages: write
-  pull-requests: write
-  repository-projects: write
-  security-events: write
-  statuses: write
-
 jobs:
   run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Describe your changes

The generated GitHub Actions user has no access to the organization, thus the request for organization members fails.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
